### PR TITLE
Added support for Haskell comments in HSX

### DIFF
--- a/syntaxes/hsx-injection.json
+++ b/syntaxes/hsx-injection.json
@@ -4,6 +4,17 @@
   "injectionSelector": "L:meta.embedded.block.hsx - (source.js, source.css)",
   "patterns": [
     {
+      "begin": "{-",
+      "end": "-}",
+      "name": "comment.block.haskell",
+      "patterns": [
+        {
+          "match": "[^\\-]+",
+          "name": "comment.block.haskell"
+        }
+      ]
+    },
+    {
       "comment": "Matches {} Inside HSX: [hsx|{}|]",
       "contentName": "meta.embedded.block.haskell",
       "begin": "{",


### PR DESCRIPTION
Supports `[hsx|{-Comment-}|]` syntax

[Co-authored by GPT-4](https://platform.openai.com/playground/p/HWMwzKYg6GWTkVC3HNk3sZmM?model=gpt-4)

<img width="794" alt="image" src="https://github.com/digitallyinduced/vscode-hsx/assets/2072185/03616529-e000-493f-9814-fb1b62d57834">
